### PR TITLE
Jonathanmaw/fix build tar

### DIFF
--- a/archival/libarchive/open_transformer.c
+++ b/archival/libarchive/open_transformer.c
@@ -200,7 +200,7 @@ int FAST_FUNC open_zipped(const char *fname)
 	 || (ENABLE_FEATURE_SEAMLESS_BZ2)
 	 || (ENABLE_FEATURE_SEAMLESS_XZ)
 	) {
-		setup_unzip_on_fd(fd, /*fail_if_not_detected:*/ 1);
+		setup_unzip_on_fd(fd, /*fail_if_not_detected:*/ 0);
 	}
 
 	return fd;

--- a/coreutils/date.c
+++ b/coreutils/date.c
@@ -260,11 +260,7 @@ int date_main(int argc UNUSED_PARAM, char **argv)
 		settimeofday(NULL, &tz);
 
 		memset(&tz, 0, sizeof(tz));
-#ifdef __USE_BSD
 		tz.tz_minuteswest = -(tm_time.tm_gmtoff / 60);
-#else
-		tz.tz_minuteswest = -(tm_time.__tm_gmtoff / 60);
-#endif
 
 		if (settimeofday(NULL, &tz))
 		{


### PR DESCRIPTION
Hi, mossmaurice,

I tried building your busybox, and needed to fix the following things:
1. date was using the wrong definition for GMT offsets. I elected to make it use the correct version,
   but defining __USE_BSD would also work (though I think it would be misleading)
2. Fixed tar to not break when it tries to read an uncompressed tar file. Without this, builds fail higher up.
